### PR TITLE
Move to environment hook

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -2,6 +2,5 @@
 
 set -euo pipefail
 
-echo '--- Skipping git checkout'
-
+echo 'Skipping git checkout'
 export BUILDKITE_REPO=""


### PR DESCRIPTION
The global pre-checkout hook runs before plugins, so we need this plugin to run even earlier to make sure that `BUILDKITE_REPO` is blanked out before the global pre-checkout hook.